### PR TITLE
Adding --noWait switch : Feature to control You can control to print …

### DIFF
--- a/ForkRap/ForkRap/Program.cs
+++ b/ForkRap/ForkRap/Program.cs
@@ -25,9 +25,16 @@ namespace ForkRap
             }
             if (args.Length >3)
             {
-                System.Console.WriteLine("Error: Do not get fancy with extra parameters. Please correct!");
-                System.Console.WriteLine("Syntax: forkwrap <url> <number_of_times> <destination_folder_path>");
-                return;
+                if(args[3] == "--noWait" || args[3] == "--nowait" || args[3] == "--NOWAIT" || args[3] == "--NoWait")
+                {
+                    LoopThrough.noWaitMode = true;
+                }
+                else
+                {
+                    System.Console.WriteLine("Error: Do not get fancy with extra parameters. Please correct!");
+                    System.Console.WriteLine("Syntax: forkwrap <url> <number_of_times> <destination_folder_path>");
+                    return;
+                }
             }
 
             // The Main program logic starts


### PR DESCRIPTION
…wait for threads to wait for for completion before spawning a new one.

This is a feature addition: NoWait-Switch-To-Control-Multithreading-Behavior

now switch can be used:
--noSwitch  or many of its allowed variations